### PR TITLE
Added version DMagick_No_Display to disable the entire display subsystem

### DIFF
--- a/dmagick/Array.d
+++ b/dmagick/Array.d
@@ -31,7 +31,13 @@ import dmagick.c.montage;
 import dmagick.c.statistic;
 import dmagick.c.quantize;
 
-version(Windows) import dmagick.internal.Windows;
+version(DMagick_No_Display)
+{
+}
+else
+{
+	version(Windows) import dmagick.internal.Windows;
+}
 
 /// See_Also: $(CXREF layer, _ImageLayerMethod)
 public alias dmagick.c.layer.ImageLayerMethod ImageLayerMethod;
@@ -167,19 +173,25 @@ void compositeLayers(
  */
 void display(Image[] images)
 {
-	version(Windows)
+	version(DMagick_No_Display)
 	{
-		Window win = new Window(images);
-		win.display();
 	}
 	else
 	{
-		linkImages(images);
-		scope(exit) unlinkImages(images);
+		version(Windows)
+		{
+			Window win = new Window(images);
+			win.display();
+		}
+		else
+		{
+			linkImages(images);
+			scope(exit) unlinkImages(images);
 
-		DisplayImages(images[0].options.imageInfo, images[0].imageRef);
+			DisplayImages(images[0].options.imageInfo, images[0].imageRef);
 
-		DMagickException.throwException(&(images[0].imageRef.exception));
+			DMagickException.throwException(&(images[0].imageRef.exception));
+		}
 	}
 }
 

--- a/dmagick/Image.d
+++ b/dmagick/Image.d
@@ -25,7 +25,13 @@ import dmagick.ImageView;
 import dmagick.Options;
 import dmagick.Utils;
 
-version(Windows) import dmagick.internal.Windows;
+version(DMagick_No_Display)
+{
+}
+else
+{
+	version(Windows) import dmagick.internal.Windows;
+}
 
 //Import all translated c headers.
 import dmagick.c.MagickCore;
@@ -1225,16 +1231,22 @@ class Image
 	 */
 	void display()
 	{
-		version(Windows)
+		version(DMagick_No_Display)
 		{
-			Window win = new Window(this);
-			win.display();
 		}
 		else
 		{
-			DisplayImages(options.imageInfo, imageRef);
+			version(Windows)
+			{
+				Window win = new Window(this);
+				win.display();
+			}
+			else
+			{
+				DisplayImages(options.imageInfo, imageRef);
 
-			DMagickException.throwException(&(imageRef.exception));
+				DMagickException.throwException(&(imageRef.exception));
+			}
 		}
 	}
 


### PR DESCRIPTION
Allows users, like me, who only want to build a pure CLI application to avoid dependencies on a GUI system.

I chose to express this in the negative so that users will, as has been the case heretofore, get the full functionality in the default case.  Users who explicitly don't want the GUI operations can declare the version at compile time and it will be gone.

I also chose to leave the display functions stubbed as this prevents API differences: the functions will still be there, but simply won't operate.  Users who choose to call them will have had to expressly declare that they don't work and so _shouldn't_ be surprised that the functions don't do anything!

To be plain: adding -version=DMagick_No_Display to the compiler command will eliminate the need to link User32.lib under Windows, and cause no graphical windows to show when the example code is executed.
