### PR TITLE
Ensure that DMagick is not rebuilt unnecessarily.

### DIFF
--- a/build-aux/magickVersion.sh
+++ b/build-aux/magickVersion.sh
@@ -2,6 +2,10 @@
 
 echo $PACKAGE_DIR
 
+CACHE_FILE=$PACKAGE_DIR/build-aux/magickVersion.cache
+
+MAGICK_VERSION_CACHED="$(cat $CACHE_FILE 2>/dev/null)"
+
 MAGICK_VERSION=$(pkg-config --modversion MagickCore | tr -d '.')
 MAGICK_VERSION_TEXT=$(pkg-config --modversion MagickCore)
 MAGICK_QUANTUM_DEPTH="16"
@@ -19,7 +23,11 @@ if [ -n "$(pkg-config --variable=libname MagickCore | grep HDRI)" ]; then
     MAGICK_HDRI="true"
 fi
 
-sed 's/@MagickLibVersion@/'$MAGICK_VERSION'/g' "$PACKAGE_DIR/dmagick/c/magickVersion.d.in" | \
-sed 's/@MagickLibVersionText@/'$MAGICK_VERSION_TEXT'/g' | \
-sed 's/@QuantumDepth@/'$MAGICK_QUANTUM_DEPTH'/g' | \
-sed 's/@HDRI@/'$MAGICK_HDRI'/g' > "$PACKAGE_DIR/dmagick/c/magickVersion.d"
+if [ "$MAGICK_VERSION_CACHED" != "$MAGICK_VERSION_TEXT" ]; then
+    echo -n "$MAGICK_VERSION_TEXT" > $CACHE_FILE
+
+    sed 's/@MagickLibVersion@/'$MAGICK_VERSION'/g' "$PACKAGE_DIR/dmagick/c/magickVersion.d.in" | \
+    sed 's/@MagickLibVersionText@/'$MAGICK_VERSION_TEXT'/g' | \
+    sed 's/@QuantumDepth@/'$MAGICK_QUANTUM_DEPTH'/g' | \
+    sed 's/@HDRI@/'$MAGICK_HDRI'/g' > "$PACKAGE_DIR/dmagick/c/magickVersion.d"
+fi


### PR DESCRIPTION
Prevents dmagick/c/magickVersion.d from being written unless its content has changed, thereby avoiding the file's updated mtime from triggering an unnecessary rebuild.

Fixes: https://github.com/MikeWey/DMagick/issues/24